### PR TITLE
fix(schema.html): Remove inactive project/site

### DIFF
--- a/schema.html
+++ b/schema.html
@@ -169,16 +169,6 @@ title: Schema
   </div>
   <div class="row integration">
     <div class="col-xs-2">
-      <img style="width: 35px;" src="https://resumefodder.com/favicon.ico">
-    </div>
-    <div class="col-xs-10">
-      <p><strong>Resume Fodder</strong></p>
-      <p><a href="https://resumefodder.com/generate.html">https://resumefodder.com</a></p>
-      <p>Generate a Microsoft Word resume from JSON Resume data,
-online or from your own computer.</p>
-    </div>
-  <div class="row integration">
-    <div class="col-xs-2">
       <img style="width: 35px;" src="https://velocv.com/favicon.ico">
     </div>
     <div class="col-xs-10">
@@ -187,7 +177,6 @@ online or from your own computer.</p>
       <p>Resumé builder completely based on jsonResume with 1 click LinkedIn import (multilanguage profiles supported).</p>
     </div>
   </div>
-</div>
 </div>
 
 


### PR DESCRIPTION
The listing for 'resumefodder.com' appears to be useless, as the website is
not operational, and the project itself was last updated 3 years ago (at
this repo: https://gitlab.com/steve-perkins/ResumeFodder). Since this is
the case, I think it should probably be removed. Of course, this also means 
there's currently a missing image on this page.

This change also corrects inconsistent HTML structure (which is also a
result of this listing's existence).