### PR TITLE
Update example schema's work.company to work.name

### DIFF
--- a/schema.html
+++ b/schema.html
@@ -64,7 +64,7 @@ title: Schema
     }]
   },
   "work": [{
-    "company": <span>"Company",</span>
+    "name": <span>"Company",</span>
     "position": <span>"President",</span>
     "website": <span>"http://company.com",</span>
     "startDate": <span>"2013-01-01",</span>


### PR DESCRIPTION
The key `work.company` seems to have been changed to `work.name`. This PR updates the sample schema docs on the website.