### PR TITLE
Use correct field name for work entries ("company" should be "name")

### DIFF
--- a/schema.html
+++ b/schema.html
@@ -64,7 +64,7 @@ title: Schema
     }]
   },
   "work": [{
-    "company": <span>"Company",</span>
+    "name": <span>"Company",</span>
     "position": <span>"President",</span>
     "website": <span>"http://company.com",</span>
     "startDate": <span>"2013-01-01",</span>


### PR DESCRIPTION
Five years ago the `"company"` field in the `"work"` array was renamed to `"name"`.  Hopefully this helps folks have a resume layout that actually renders correctly.