### PR TITLE
refactor: move team members into data files

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,0 +1,48 @@
+core-team:
+  - name: Mattias Erming
+    avatar: https://avatars.githubusercontent.com/u/2502500?&s=50
+    github: erming
+    twitter: mattiaserming
+
+  - name: Roland Sharp
+    avatar: https://avatars.githubusercontent.com/u/1858973?&s=50
+    github: rolandnsharp
+    twitter: rolandnsharp
+
+  - name: Thomas Davis
+    avatar: https://avatars.githubusercontent.com/u/416209?&s=50
+    github: thomasdavis
+    twitter: ajaxdavis
+
+  - name: Mike Chelen
+    avatar: https://avatars.githubusercontent.com/u/30691?&s=50
+    github: mchelen
+    twitter: mchelen
+
+  - name: Mudassir Ali
+    avatar: https://avatars.githubusercontent.com/u/1861842?&s=50
+    github: mudassir0909
+    twitter: guesswhat4951
+
+  - name: Peter Dave Hello
+    avatar: https://avatars.githubusercontent.com/u/3691490?&s=50
+    github: PeterDaveHello
+    twitter: PeterDaveHello
+
+  - name: Seth Falco
+    avatar: https://avatars.githubusercontent.com/u/22801583?&s=50
+    github: SethFalco
+    twitter: SethFalco
+
+standards-committee:
+  - name: Daan Debie
+    avatar: https://avatars.githubusercontent.com/u/854991?s=50
+    github: DandyDev
+
+  - name: Ursula Kallio
+    avatar: https://avatars.githubusercontent.com/u/1639324?s=50
+    github: osg
+
+  - name: Walter Doekes
+    avatar: https://avatars.githubusercontent.com/u/1225014?s=50
+    github: wdoekes

--- a/team.html
+++ b/team.html
@@ -7,7 +7,7 @@ title: Team
   <div class="container">
     <div class="row">
       <div class="col-sm-4">
-        <h1>Meet the team</h2>
+        <h1>Meet the Team</h1>
       </div>
       <div class="col-sm-4">
       </div>
@@ -38,64 +38,26 @@ title: Team
       <section>
         <h3>Core Team</h3>
         <div class="row">
+          {% for member in site.data.team.core-team %}
           <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars0.githubusercontent.com/u/2502500?s=50">
-            <div class="name">Mattias Erming</div>
-            <a class="github" href="https://github.com/erming">GitHub</a>
-            <a class="twitter" href="https://twitter.com/mattiaserming">Twitter</a>
+            <img class="avatar" src="{{member.avatar}}" alt="Avatar of {{member.name}}." width="50" height="50">
+            <div class="name">{{member.name}}</div>
+            <a class="github" href="https://github.com/{{member.github}}">GitHub</a>
+            <a class="twitter" href="https://twitter.com/{{member.twitter}}">Twitter</a>
           </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars1.githubusercontent.com/u/1858973?s=50">
-            <div class="name">Roland Sharp</div>
-            <a class="github" href="https://github.com/rolandnsharp">GitHub</a>
-            <a class="twitter" href="https://twitter.com/rolandnsharp">Twitter</a>
-          </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars2.githubusercontent.com/u/416209?s=50">
-            <div class="name">Thomas Davis</div>
-            <a class="github" href="https://github.com/thomasdavis">GitHub</a>
-            <a class="twitter" href="https://twitter.com/neutralthoughts">Twitter</a>
-          </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars2.githubusercontent.com/u/30691?v=3&s=50">
-            <div class="name">Mike Chelen</div>
-            <a class="github" href="https://github.com/mchelen">GitHub</a>
-            <a class="twitter" href="https://twitter.com/mikechelen">Twitter</a>
-          </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars2.githubusercontent.com/u/1861842?v=3&s=50">
-            <div class="name">Mudassir Ali</div>
-            <a class="github" href="https://github.com/mudassir0909">GitHub</a>
-            <a class="twitter" href="https://twitter.com/guesswhat4951">Twitter</a>
-          </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars2.githubusercontent.com/u/3691490?v=3&s=50">
-            <div class="name">Peter Dave Hello</div>
-            <a class="github" href="https://github.com/PeterDaveHello">GitHub</a>
-            <a class="twitter" href="https://twitter.com/PeterDaveHello">Twitter</a>
-          </div>
-
-
+          {% endfor %}
         </div>
       </section>
       <section>
         <h3>Standards Committee</h3>
         <div class="row">
+          {% for member in site.data.team.standards-committee %}
           <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars3.githubusercontent.com/u/854991?s=50">
-            <div class="name">Daan Debie</div>
-            <a class="github" href="https://github.com/DandyDev">GitHub</a>
+            <img class="avatar" src="{{member.avatar}}" alt="Avatar of {{member.name}}." width="50" height="50">
+            <div class="name">{{member.name}}</div>
+            <a class="github" href="https://github.com/{{member.github}}">GitHub</a>
           </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars1.githubusercontent.com/u/1639324?s=50">
-            <div class="name">Ursula Kallio</div>
-            <a class="github" href="https://github.com/opensourcegrrrl">GitHub</a>
-          </div>
-          <div class="col-lg-6 person">
-            <img class="avatar" src="https://avatars1.githubusercontent.com/u/1225014?s=50">
-            <div class="name">Walter Doekes</div>
-            <a class="github" href="https://github.com/wdoekes">GitHub</a>
-          </div>
+          {% endfor %}
         </div>
       </section>
     </div>


### PR DESCRIPTION
There is a lot of duplication with showing team members, so this moves them into a data file to make it easier to maintain.

* Moves team members into a data file. (`team.yml`)
* Adds me to the core-team. 🎉 

Also corrects some social media links that from outdated usernames:
* Ursula Kallio has the GitHub username "osg".
* Thomas Davis has the Twitter username "ajaxdavis".
* Mike Chelen has the Twitter username "mchelen".

This PR also makes other small improvements in the area:
* Updates the title to use title-case to be consistent with other pages.
* Adds `width` and `height` attributes to images so there're fewer changes during page load.
* Adds `alt` attribute to images.