### PR TITLE
fix: fixes sidebar and refactors main.js

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,14 +1,19 @@
-jQuery(function($) {
+jQuery(() => {
   highlight();
   equalizeFeatureHeight();
-  renderStats();
   enableSidebar();
 });
 
+/**
+ * Apply the class "active" to the current page in the navigation bar.
+ */
 function highlight() {
   $("#nav a").each(function() {
-    var self = $(this);
-    if (window.location.pathname.indexOf(self.attr("href")) !== -1) {
+    const self = $(this);
+    const href = self.attr("href");
+    const path = window.location.pathname;
+
+    if (path === href) {
       self.addClass("active");
       self.siblings().removeClass("active");
     }
@@ -16,50 +21,39 @@ function highlight() {
 }
 
 function equalizeFeatureHeight() {
-  var start = $("#start");
-  if (!start.length) {
+  const start = $("#start");
+
+  if (!start.length)
     return;
-  }
-  var page = $(window);
-  setInterval(function() {
-    var max = 0;
-    var items = start.find(".feature p");
+
+  setInterval(() => {
+    let max = 0;
+    const items = start.find(".feature p");
+
     items.css("height", "auto").each(function() {
-      var h = $(this).height();
-      if (h > max) {
+      const h = $(this).height();
+
+      if (h > max)
         max = h;
-      }
     });
+
     items.height(max);
   }, 240);
 }
 
-function renderStats() {
-  var stats = $("#stats");
-  if (!stats.length) {
-    return;
-  }
+function enableSidebar() {
+  const viewport = $("#viewport");
 
-  var previous = 0;
-  var options = {
-    useEasing: true,
-    useGrouping: true,
-    separator: ",",
-    decimal: "."
-  };
+  $(".lt").on("touchstart click", (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    viewport.toggleClass("open");
+  });
 
-  function enableSidebar() {
-    var viewport = $("#viewport");
-    $(".lt").on("touchstart click", function(e) {
+  $(".inner").on("touchstart click", (e) => {
+    if (viewport.hasClass("open")) {
       e.stopPropagation();
-      e.preventDefault();
-      viewport.toggleClass("open");
-    });
-    $(".inner").on("touchstart click", function(e) {
-      if (viewport.hasClass("open")) {
-        e.stopPropagation();
-        viewport.removeClass("open");
-      }
-    });
-  }
+      viewport.removeClass("open");
+    }
+  });
 }


### PR DESCRIPTION
The sidebar didn't work on mobile due to curly braces not being in the correct lines.
* Fixes the sidebar so it appears on mobile.

Also refactors the `main.js` file:
* Removes the `renderStats()` method, as this was doing nothing.
* Cleans up `highlight`, and documents that it only applies a class. (The `active` class isn't used, though.)
* Converts uses of `function()` to `() =>` unless `$(this)` is used.
* Replaces usage of `var` with `let` and `const` respectively.
