### PR TITLE
fix: include projects in jsonschema

### DIFF
--- a/schema.html
+++ b/schema.html
@@ -55,7 +55,7 @@ title: Schema
     "email": <span>"john@gmail.com",</span>
     "phone": <span>"(912) 555-4321",</span>
     "url": <span>"https://johndoe.com",</span>
-    "summary": <span>"A summary of John Doe...",</span>
+    "summary": <span>"A summary of John Doe…",</span>
     "location": {
       "address": <span>"2712 Broadway St",</span>
       "postalCode": <span>"CA 94115",</span>
@@ -75,7 +75,7 @@ title: Schema
     "url": <span>"https://company.com",</span>
     "startDate": <span>"2013-01-01",</span>
     "endDate": <span>"2014-01-01",</span>
-    "summary": <span>"Description...",</span>
+    "summary": <span>"Description…",</span>
     "highlights": [
       <span>"Started the company"</span>
     ]
@@ -86,7 +86,7 @@ title: Schema
     "url": <span>"https://organization.com/",</span>
     "startDate": <span>"2012-01-01",</span>
     "endDate": <span>"2013-01-01",</span>
-    "summary": <span>"Description...",</span>
+    "summary": <span>"Description…",</span>
     "highlights": [
       <span>"Awarded 'Volunteer of the Month'"</span>
     ]
@@ -114,7 +114,7 @@ title: Schema
     "publisher": <span>"Company",</span>
     "releaseDate": <span>"2014-10-01",</span>
     "url": <span>"https://publication.com",</span>
-    "summary": <span>"Description..."</span>
+    "summary": <span>"Description…"</span>
   }],
   "skills": [{
     "name": <span>"Web Development",</span>
@@ -122,7 +122,7 @@ title: Schema
     "keywords": [
       <span>"HTML",</span>
       <span>"CSS",</span>
-      <span>"Javascript"</span>
+      <span>"JavaScript"</span>
     ]
   }],
   "languages": [{
@@ -138,7 +138,25 @@ title: Schema
   }],
   "references": [{
     "name": <span>"Jane Doe",</span>
-    "reference": <span>"Reference..."</span>
+    "reference": <span>"Reference…"</span>
+  }],
+  "projects": [{
+    "name": <span>"Project",</span>
+    "description": <span>"Description…",</span>
+    "highlights": [
+      <span>"Won award at AIHacks 2016"</span>
+    ],
+    "keywords": [
+      <span>"HTML"</span>
+    ],
+    "startDate": <span>"2019-01-01",</span>
+    "endDate": <span>"2021-01-01",</span>
+    "url": <span>"https://project.com/",</span>
+    "roles": [
+      <span>"Team Lead"</span>
+    ],
+    "entity": <span>"Entity",</span>
+    "type": <span>"application"</span>
   }]
 }
 </pre>


### PR DESCRIPTION
Adds the `project` property to the example `resume.json`.

Also makes a few minor changes:
* Fixes typo: "Javascript" -> JavaScript
* Replaces 3 dots (... / `...`) with an ellipsis (… / `…`).

#### Related To
* Closes https://github.com/jsonresume/resume-website/issues/89
