### PR TITLE
Fix URL of hugo-mod-json-resume project

### DIFF
--- a/_data/projects.yaml
+++ b/_data/projects.yaml
@@ -30,6 +30,6 @@
   link: http://hackage.haskell.org/package/jsonresume
   description: This library encodes JSON Resume standard in Haskell datatypes, and provides a parser to read a CV in the JSON Resume format.
 
-- name: hugo-json-resume
-  link: https://github.com/schnerring/hugo-json-resume
+- name: hugo-mod-json-resume
+  link: https://github.com/schnerring/hugo-mod-json-resume
   description: A Hugo module containing templates to integrate multilingual JSON Resume data into your Hugo website.


### PR DESCRIPTION
I changed the project name from `hugo-json-resume` to `hugo-mod-json-resume`. Just wanted to update this here as well in case GitHub decides to remove the redirect at one point.