### PR TITLE
fix: remove trailing comma from example schema

### DIFF
--- a/schema.html
+++ b/schema.html
@@ -109,7 +109,7 @@ title: Schema
     "name": <span>"Certificate",</span>
     "date": <span>"2021-11-07",</span>
     "issuer": <span>"Company",</span>
-    "url": <span>"https://certificate.com",</span>
+    "url": <span>"https://certificate.com"</span>
   }],
   "publications": [{
     "name": <span>"Publication",</span>


### PR DESCRIPTION
The [example on the schema page](https://jsonresume.org/schema/) has a trailing comma: this PR removes it.

<img width="850" alt="trailing-comma" src="https://user-images.githubusercontent.com/1855109/158777316-8228dd9d-f03f-4461-b2d4-3bd100519265.png">
