### PR TITLE
Fix JSON syntax - Remove trailing comma

### DIFF
--- a/schema.html
+++ b/schema.html
@@ -109,7 +109,7 @@ title: Schema
     "name": <span>"Certificate",</span>
     "date": <span>"2021-11-07",</span>
     "issuer": <span>"Company",</span>
-    "url": <span>"https://certificate.com",</span>
+    "url": <span>"https://certificate.com"</span>
   }],
   "publications": [{
     "name": <span>"Publication",</span>


### PR DESCRIPTION
This PR that removes the trailing comma in the JSON schema example. The trailing comma causes an error when copied and pasted as is. 