### PR TITLE
fix: don't deploy non-site files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,11 @@ title: JSON Resume
 description: "JSON Resume is a community driven open source initiative to create a JSON based standard for resumes."
 permalink: pretty
 markdown: kramdown
-include: [/.well-known]
+include:
+  - /.well-known
+exclude:
+  - provision/
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - Vagrantfile


### PR DESCRIPTION
We're pushing quite a few files out (accessible via URL) that aren't needed.
Let's take those down.